### PR TITLE
update nextcloud 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package version
-ENV NEXTCLOUD_VER="11.0.3"
+ENV NEXTCLOUD_VER="12.0.0"
 
 # environment settings
 ENV NEXTCLOUD_PATH="/config/www/nextcloud"
@@ -62,6 +62,7 @@ RUN \
 	php7-mbstring \
 	php7-mcrypt \
 	php7-memcached \
+	php7-opcache \
 	php7-pcntl \
 	php7-pdo_mysql \
 	php7-pdo_pgsql \
@@ -89,6 +90,8 @@ RUN \
 	build-dependencies && \
 
 # configure php and nginx for nextcloud
+ sed -i 's/max_execution_time = .*/max_execution_time = 300/g' /etc/php7/php.ini && \
+ sed -i 's/.*request_terminate_timeout =.*/request_terminate_timeout = 300/g' /etc/php7/php-fpm.d/www.conf && \
  echo "extension="smbclient.so"" > /etc/php7/conf.d/00_smbclient.ini && \
  sed -i \
  's/;always_populate_raw_post_data = -1/always_populate_raw_post_data = -1/g' \

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Access the webui at `<your-ip>:443`, for more information check out [Nextcloud][
 
 Please note you will need a MySQL/MariaDB or other backend database to set this up.  Also please look [here](https://docs.nextcloud.com/server/11/admin_manual/installation/system_requirements.html#database-requirements-for-mysql-mariadb) for how to configure your database with regard to binlog format and installation.
 
+If updating to nextcloud 12 you will need to comment out line `add_header X-Frame-Options "SAMEORIGIN";` in the file /config/nginx/site-confs/default
+
 ## Info
 
 * Monitor the logs of the container in realtime `docker logs -f nextcloud`.
@@ -81,5 +83,6 @@ Please note you will need a MySQL/MariaDB or other backend database to set this 
 
 ## Versions
 
++ **22.05.17:** Update to nextcloud 12.0, adding required dependecies and note about commenting out SAMEORIGIN; line.
 + **03.05.17:** Update to php 7.1x.
 + **07.03.17:** Initial Release

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -20,7 +20,7 @@ server {
   # Add headers to serve security related headers
   add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
   add_header X-Content-Type-Options nosniff;
-  add_header X-Frame-Options "SAMEORIGIN";
+  #add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection "1; mode=block";
   add_header X-Robots-Tag none;
   add_header X-Download-Options noopen;
@@ -83,6 +83,7 @@ server {
     fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
     fastcgi_pass php-handler;
     fastcgi_intercept_errors on;
+    fastcgi_read_timeout 300;
   }
 
   # Adding the cache control header for js and css files


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ bump to nextcloud 12 as default install
+ add dependency php7-opcache
+ add note to README about commenting line in default site-conf.
+ increase max execution time for arm64 to 300.