### PR TITLE
Update `default`

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -20,12 +20,13 @@ server {
   # Add headers to serve security related headers
   add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
   add_header X-Content-Type-Options nosniff;
-  #add_header X-Frame-Options "SAMEORIGIN";
+  # add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection "1; mode=block";
   add_header X-Robots-Tag none;
   add_header X-Download-Options noopen;
   add_header X-Permitted-Cross-Domain-Policies none;
-
+  add_header Referrer-Policy no-referrer always;
+  
   # Path to the root of your installation
   root /config/www/nextcloud/;
   # set max upload size
@@ -83,7 +84,6 @@ server {
     fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
     fastcgi_pass php-handler;
     fastcgi_intercept_errors on;
-    fastcgi_read_timeout 300;
   }
 
   # Adding the cache control header for js and css files
@@ -98,6 +98,7 @@ server {
     add_header X-Robots-Tag none;
     add_header X-Download-Options noopen;
     add_header X-Permitted-Cross-Domain-Policies none;
+    add_header Referrer-Policy no-referrer always;
     # Optional: Don't log access to assets
     access_log off;
   }


### PR DESCRIPTION
Fixes the `"The "Referrer-Policy" HTTP header is not set to "no-referrer", "no-referrer-when-downgrade", "strict-origin" or "strict-origin-when-cross-origin". This can leak referer information."` message

